### PR TITLE
fix an open issue that previousText and nextText show twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,10 @@
 export default {
     template: `<div class="ui pagination menu">
-      <a v-if="showPrevious() || currentPage <= 1" :class="{ 'disabled' : currentPage <= 1 }" class="item">
-        {{ config.previousText }}
-      </a>
       <a v-if="currentPage > 1" @click.prevent="changePage(currentPage - 1)" class="item">
         {{ config.previousText }}
       </a>
       <a v-for="num in array" :class="{ 'active': num === currentPage }" class="item" @click.prevent="changePage(num)">
         {{ num }}
-      </a>
-      <a v-if="showNext() || currentPage === lastPage || lastPage === 0" :class="{ 'disabled' : currentPage === lastPage || lastPage === 0 }" class="item">
-        {{ config.nextText }}
       </a>
       <a v-if="currentPage < lastPage" @click.prevent="changePage(currentPage + 1)" class="item">
         {{ config.nextText }}


### PR DESCRIPTION
There is an open issue reported on the NPM.
I encountered this bug as well when I was using your pagination component.
I have fixed it. Would you mind take a look at it? 